### PR TITLE
nextcloudApps: continue to support license

### DIFF
--- a/pkgs/build-support/fetchnextcloudapp/default.nix
+++ b/pkgs/build-support/fetchnextcloudapp/default.nix
@@ -4,18 +4,23 @@
 , sha256 ? ""
 , appName ? null
 , appVersion ? null
-, licenses
+, license ? null
+, licenses ? [ ]
 , patches ? [ ]
 , description ? null
 , homepage ? null
 , unpack ? false # whether to use fetchzip rather than fetchurl
 }:
+let
+  licenses' = lib.optional (license != null) license ++ licenses;
+  licenses'' = assert lib.assertMsg (lib.length licenses' > 0) "License(s) for ${url} must be specified"; licenses';
+in
 applyPatches ({
   inherit patches;
   src = (if unpack then fetchzip else fetchurl) {
     inherit url hash sha256;
     meta = {
-      license = map (license: lib.licenses.${license}) licenses;
+      license = map (license: lib.licenses.${license}) licenses'';
       longDescription = description;
       inherit homepage;
     } // lib.optionalAttrs (description != null) {


### PR DESCRIPTION
## Description of changes

Per the feedback from @ma27 on nixos/nixpkgs#335595, let's continue to support the license argument for out-of-tree users.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).